### PR TITLE
Allow to define listen address

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ victoriametrics_vmselect_service_args: "" # Add extra variables here . Found mor
 ## variables for vminsert nodes
 victoriametrics_vminsert_service_args: "" # Add extra variables here . Found more options with vminsert-prod --help
 victoriametrics_vminsert_memory_allowed_percent: "60"
+
+# variables for service's listen address
+victoriametrics_vmstorage_listen_address: "{{ ansible_default_ipv4.address }}"
+victoriametrics_vmselect_listen_address: "{{ ansible_default_ipv4.address }}"
+victoriametrics_vminsert_listen_address: "{{ ansible_default_ipv4.address }}"
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,12 @@ victoriametrics_vmselect_memory_allowed_percent: "60"
 victoriametrics_vminsert_service_args: ""
 victoriametrics_vminsert_memory_allowed_percent: "60"
 
-#sysctl settings. more info : 
+# variables for service's listen address
+victoriametrics_vmstorage_listen_address: "{{ ansible_default_ipv4.address }}"
+victoriametrics_vmselect_listen_address: "{{ ansible_default_ipv4.address }}"
+victoriametrics_vminsert_listen_address: "{{ ansible_default_ipv4.address }}"
+
+#sysctl settings. more info :
 custom_sysctl:
 # http://www.nateware.com/linux-network-tuning-for-2013.html
 # Increase Linux autotuning TCP buffer limits

--- a/templates/victoriametrics-vminsert.service.j2
+++ b/templates/victoriametrics-vminsert.service.j2
@@ -10,7 +10,7 @@ StartLimitBurst=5
 StartLimitInterval=0
 Restart=on-failure
 RestartSec=1
-ExecStart=/usr/local/bin/victoriametrics/vminsert-prod {% if victoriametrics_vminsert_service_args is defined %}{{ victoriametrics_vminsert_service_args }}{% endif %} -memory.allowedPercent={{ victoriametrics_vminsert_memory_allowed_percent }} -storageNode={%for host in groups['vmstorage']%}{{hostvars[host].ansible_default_ipv4.address}}:8400{% if not loop.last %},{% endif %}{% endfor %}
+ExecStart=/usr/local/bin/victoriametrics/vminsert-prod {% if victoriametrics_vminsert_service_args is defined %}{{ victoriametrics_vminsert_service_args }}{% endif %} -memory.allowedPercent={{ victoriametrics_vminsert_memory_allowed_percent }} -storageNode={%for host in groups['vmstorage']%}{{hostvars[host].victoriametrics_vmstorage_listen_address|default(hostvars[host].ansible_default_ipv4.address)}}:8400{% if not loop.last %},{% endif %}{% endfor %}
 
 ExecStop=/bin/kill -s SIGTERM $MAINPID
 

--- a/templates/victoriametrics-vmselect.service.j2
+++ b/templates/victoriametrics-vmselect.service.j2
@@ -10,7 +10,7 @@ StartLimitBurst=5
 StartLimitInterval=0
 Restart=on-failure
 RestartSec=1    
-ExecStart=/usr/local/bin/victoriametrics/vmselect-prod {% if victoriametrics_vmselect_service_args is defined %}{{ victoriametrics_vmselect_service_args }}{% endif %} -cacheDataPath={{ victoriametrics_vmselect_cache_dir }} -memory.allowedPercent={{ victoriametrics_vmselect_memory_allowed_percent }} -storageNode={%for host in groups['vmstorage']%}{{hostvars[host].ansible_default_ipv4.address}}:8401{% if not loop.last %},{% endif %}{% endfor %} -selectNode={%for host in groups['vmselect']%}{{hostvars[host].ansible_default_ipv4.address}}:8141{% if not loop.last %},{% endif %}{% endfor %}
+ExecStart=/usr/local/bin/victoriametrics/vmselect-prod {% if victoriametrics_vmselect_service_args is defined %}{{ victoriametrics_vmselect_service_args }}{% endif %} -cacheDataPath={{ victoriametrics_vmselect_cache_dir }} -memory.allowedPercent={{ victoriametrics_vmselect_memory_allowed_percent }} -storageNode={%for host in groups['vmstorage']%}{{hostvars[host]['victoriametrics_vmstorage_listen_address']|default(hostvars[host].ansible_default_ipv4.address)}}:8401{% if not loop.last %},{% endif %}{% endfor %} -selectNode={%for host in groups['vmselect']%}{{hostvars[host]['victoriametrics_vmselect_listen_address']|default(hostvars[host].ansible_default_ipv4.address)}}:8141{% if not loop.last %},{% endif %}{% endfor %}
 
 ExecStop=/bin/kill -s SIGTERM $MAINPID
 


### PR DESCRIPTION
The previous version of this role was to configure VM* services to
listen on `ansible_default_ipv4.address`. This might not be what the
user wants especially when the host/instance has several interfaces.

This commit allow user to define the listen address of each services
with a fallback on the previous value, namely
`ansible_default_ipv4.address`.

The template also includes one last safeguard to avoid undefined variable
when ansible tries to resolve
`hostvars[host].victoriametrics_vmstorage_listen_address`. This variable
will be define **only** if the user has run a `setup` task on all hosts of
the cluster which might not be the case.

Example:
```
fatal: [vminsert-1]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'victoriametrics_vmstorage_listen_address'"}
```